### PR TITLE
feature: added error page will be rendered not definded urls

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,12 @@ ReactDOM.render(
               <Route path="/" element={<Main />} />
             </Route>
 
-            <Route path="*" element={<Error />} />
+            <Route
+              path="*"
+              element={
+                <Error error={{ code: 404, message: "Page Not Found" }} />
+              }
+            />
           </Route>
         </Routes>
       </AuthProvider>

--- a/src/pages/Error.js
+++ b/src/pages/Error.js
@@ -1,7 +1,60 @@
 import React from "react";
+import { useNavigate } from "react-router-dom";
+import styled from "styled-components";
+import propTypes from "prop-types";
 
-function Error() {
-  return <div>Error</div>;
+import Logo from "../components/Logo";
+import ButtonLarge from "../components/ButtonLarge";
+
+function Error({ error }) {
+  const navigate = useNavigate();
+
+  return (
+    <ErrorLayout>
+      <LogoBox>
+        <Logo
+          size={{
+            width: "350px",
+            height: "270px",
+            font: "30px",
+            weight: "normal",
+          }}
+          text={`${error.code} ${error.message}`}
+        />
+      </LogoBox>
+      <ButtonLarge
+        text="메인 페이지로"
+        onClick={() => {
+          navigate("/");
+        }}
+      />
+    </ErrorLayout>
+  );
 }
+
+const ErrorLayout = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: inherit;
+  height: inherit;
+  color: white;
+
+  button {
+    position: absolute;
+    bottom: 10%;
+  }
+`;
+
+const LogoBox = styled.div`
+  position: relative;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -70%);
+`;
+
+Error.propTypes = {
+  error: propTypes.object.isRequired,
+};
 
 export default Error;


### PR DESCRIPTION
# Feature/error

## 노션 칸반 링크

- [Error component](https://www.notion.so/bc2a53e91cde4294856888e5b38fc6dc?v=cc148201de2a4782920edae951a023a4&p=78c1efa46bf547ad8288c7165deb3cbf)

## 카드에서 구현 혹은 해결하려는 내용

- React Router에서 "/*"이거나, 서버 response에 error.message가 포함되어 있는 경우 Error 컴포넌트가 렌더 된다.
- 재사용성을 고려하여 error객체를 프롭으로 주고 있습니다. 
